### PR TITLE
add unused import

### DIFF
--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -34,6 +34,8 @@
 //! [`LogicalPlan`]: datafusion_expr::logical_plan::LogicalPlan
 //! [`Expr`]: datafusion_expr::expr::Expr
 
+use std::sync::Arc;
+
 mod cte;
 mod expr;
 pub mod parser;


### PR DESCRIPTION
Demo for #12588

Trying to commit, we now get a failure from the clippy script:

```
code/datafusion 127 ➤ git commit -am 'add unused import'
INFO: cargo clippy ...
+ cargo clippy --all-targets --workspace --features avro,pyarrow -- -D warnings
   Compiling pyo3-build-config v0.22.2
   Compiling pyo3-macros-backend v0.22.2
   Compiling pyo3-ffi v0.22.2
   Compiling pyo3 v0.22.2
   Compiling pyo3-macros v0.22.2
    Checking arrow v53.0.0
    Checking datafusion-common v42.0.0 (/Users/samuel/code/datafusion/datafusion/common)
    Checking datafusion-expr-common v42.0.0 (/Users/samuel/code/datafusion/datafusion/expr-common)
    Checking datafusion-functions-window-common v42.0.0 (/Users/samuel/code/datafusion/datafusion/functions-window-common)
    Checking test-utils v0.1.0 (/Users/samuel/code/datafusion/test-utils)
    Checking datafusion-proto-common v42.0.0 (/Users/samuel/code/datafusion/datafusion/proto-common)
    Checking datafusion-physical-expr-common v42.0.0 (/Users/samuel/code/datafusion/datafusion/physical-expr-common)
    Checking datafusion-functions-aggregate-common v42.0.0 (/Users/samuel/code/datafusion/datafusion/functions-aggregate-common)
    Checking datafusion-expr v42.0.0 (/Users/samuel/code/datafusion/datafusion/expr)
    Checking datafusion-execution v42.0.0 (/Users/samuel/code/datafusion/datafusion/execution)
    Checking datafusion-sql v42.0.0 (/Users/samuel/code/datafusion/datafusion/sql)
    Checking datafusion-functions-window v42.0.0 (/Users/samuel/code/datafusion/datafusion/functions-window)
error: unused import: `std::sync::Arc`
  --> datafusion/sql/src/lib.rs:37:5
   |
37 | use std::sync::Arc;
   |     ^^^^^^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`

    Checking datafusion-functions v42.0.0 (/Users/samuel/code/datafusion/datafusion/functions)
    Checking datafusion-physical-expr v42.0.0 (/Users/samuel/code/datafusion/datafusion/physical-expr)
error: could not compile `datafusion-sql` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
code/datafusion 1 ➤ gs
## unused_imports-demo
 M datafusion/sql/src/lib.rs
```